### PR TITLE
Fix parameter extraction when the API is mounted with a path prefix

### DIFF
--- a/lib/tentd/api/router/extract_params.rb
+++ b/lib/tentd/api/router/extract_params.rb
@@ -22,7 +22,7 @@ module TentD
         end
 
         def extract_params(env)
-          route = env['request'].script_name
+          route = env[Rack::Mount::Prefix::KEY]
           route = '/' if route.empty?
           return unless match = pattern.match(route)
           values = match.captures.to_a.map { |v| URI.decode_www_form_component(v) if v }


### PR DESCRIPTION
The API currently looks at the `SCRIPT_NAME` env variable instead of the route matched by `Rack::RouteSet`. This causes failure when the SCRIPT_NAME is prefixed, i.e. TentD is mounted somewhere under `/prefix`.
