### PR TITLE
Fix type serialization

### DIFF
--- a/lib/tentd/api/posts.rb
+++ b/lib/tentd/api/posts.rb
@@ -24,7 +24,7 @@ module TentD
           if authorize_env?(env, :read_posts)
             conditions = { :id => env.params.post_id }
             unless env.current_auth.post_types.include?('all')
-              conditions[:type] = env.current_auth.post_types.map { |t| TentType.new(t).uri }
+              conditions[:type_base] = env.current_auth.post_types.map { |t| TentType.new(t).base }
             end
             post = Model::Post.first(conditions)
           else
@@ -46,14 +46,14 @@ module TentD
             conditions[:published_at.gt] = Time.at(env.params.since_time.to_i) if env.params.since_time
             conditions[:published_at.lt] = Time.at(env.params.before_time.to_i) if env.params.before_time
             if env.params.post_types
-              conditions[:type] = env.params.post_types.split(',').map do |type|
-                URI.unescape(TentType.new(type).uri)
+              conditions[:type_base] = env.params.post_types.split(',').map do |type|
+                URI.unescape(type)
               end.select do |type|
                 env.current_auth.post_types.include?('all') ||
                 env.current_auth.post_types.include?(type)
               end
             elsif !env.current_auth.post_types.include?('all')
-              conditions[:type] = env.current_auth.post_types.map { |t| TentType.new(t).uri }
+              conditions[:type_base] = env.current_auth.post_types.map { |t| TentType.new(t).base }
             end
             if env.params.limit
               conditions[:limit] = [env.params.limit.to_i, TentD::API::MAX_PER_PAGE].min

--- a/lib/tentd/model/app_authorization.rb
+++ b/lib/tentd/model/app_authorization.rb
@@ -53,11 +53,11 @@ module TentD
         saved = update(data.slice(:post_types, :profile_info_types, :scopes, :notification_url))
 
         if saved && data[:post_types] && data[:post_types] != _post_types
-          notification_subscriptions.all(:type.not => post_types).destroy
+          notification_subscriptions.all(:type_base.not => post_types).destroy
 
           data[:post_types].each do |type|
-            next if notification_subscriptions.first(:type => type)
-            notification_subscriptions.create(:type => type)
+            next if notification_subscriptions.first(:type_base => type)
+            notification_subscriptions.create(:type_base => type)
           end
         end
 

--- a/lib/tentd/model/notification_subscription.rb
+++ b/lib/tentd/model/notification_subscription.rb
@@ -18,7 +18,7 @@ module TentD
       end
 
       def self.notify_all(type, post_id)
-        all(:type => [type, 'all'], :fields => [:id, :app_authorization_id, :follower_id]).each do |subscription|
+        all(:type_base => [type.base, 'all'], :fields => [:id, :app_authorization_id, :follower_id]).each do |subscription|
           next unless Post.first(:id => post_id, :fields => [:id, :original, :public]).can_notify?(subscription.subject)
           Notifications::NOTIFY_QUEUE << { :subscription_id => subscription.id, :post_id => post_id }
         end

--- a/lib/tentd/model/notification_subscription.rb
+++ b/lib/tentd/model/notification_subscription.rb
@@ -33,6 +33,7 @@ module TentD
           client = TentClient.new
           profile, server_url = client.discover(entity).get_profile
           server_urls = API::CoreProfileData.new(profile).servers
+          #raise [profile, server_url].inspect
           client = TentClient.new(server_urls)
         end
         client.post.create(post.as_json)

--- a/lib/tentd/model/notification_subscription.rb
+++ b/lib/tentd/model/notification_subscription.rb
@@ -33,7 +33,6 @@ module TentD
           client = TentClient.new
           profile, server_url = client.discover(entity).get_profile
           server_urls = API::CoreProfileData.new(profile).servers
-          #raise [profile, server_url].inspect
           client = TentClient.new(server_urls)
         end
         client.post.create(post.as_json)

--- a/lib/tentd/model/type_properties.rb
+++ b/lib/tentd/model/type_properties.rb
@@ -3,30 +3,28 @@ module TentD
     module TypeProperties
       def self.included(base)
         base.class_eval do
-          property :type, String
-          property :type_view, String, :default => lambda { |m,p|
-            TentType.new(m.type).view || 'full' unless m.type == 'all'
-          }
-          property :type_version, String, :default => lambda { |m, p|
-            TentType.new(m.type).version.to_s unless m.type == 'all'
-          }
-
-          before :save do
-            if type == 'all'
-              self.type_version = nil
-              self.type_view = 'full'
-            else
-              t = TentType.new(type)
-              self.type = t.uri
-              self.type_version ||= t.version
-              self.type_view ||= (t.view || 'full')
-            end
-          end
+          property :type_base, String
+          property :type_view, String
+          property :type_version, String
         end
       end
 
-      def full_type
-        "#{type}/v#{type_version}"
+      def type
+        TentType.new.tap do |t|
+          t.base = type_base
+          t.version = type_version
+          t.view = type_view
+        end
+      end
+
+      def type=(new_t)
+        if String === new_t
+          new_t = TentType.new(new_t)
+        end
+        
+        self.type_base = new_t.base
+        self.type_version = new_t.version
+        self.type_view = new_t.view
       end
     end
   end

--- a/lib/tentd/tent_type.rb
+++ b/lib/tentd/tent_type.rb
@@ -1,11 +1,20 @@
 module TentD
   class TentType
-    attr_reader :version, :view, :uri
+    attr_accessor :version, :view, :base
 
-    def initialize(type_uri)
-      @version = TentVersion.from_uri(type_uri)
-      @view = type_uri.to_s.split('#')[1]
-      @uri = type_uri.to_s.sub(%r{/v[^/]+$}, '')
+    def initialize(uri = nil)
+      if uri
+        @version = TentVersion.from_uri(uri)
+        view_split = uri.to_s.split('#')
+        @view = view_split[1]
+        @base = view_split[0].to_s.sub(%r{/v[^a-z/][^/]*$}, '')
+      end
+    end
+
+    def uri
+      version_part = @version.nil? ? '' : "/v#{@version}"
+      view_part = @view.nil? ? '' : "##{@view}"
+      "#{@base}#{version_part}#{view_part}"
     end
   end
 end

--- a/spec/fabricators/notification_subscriptions_fabricator.rb
+++ b/spec/fabricators/notification_subscriptions_fabricator.rb
@@ -1,3 +1,3 @@
 Fabricator(:notification_subscription, :class_name => 'TentD::Model::NotificationSubscription') do |f|
-  f.type 'https://tent.io/types/posts/status'
+  f.type_base 'https://tent.io/types/posts/status'
 end

--- a/spec/fabricators/posts_fabricator.rb
+++ b/spec/fabricators/posts_fabricator.rb
@@ -2,7 +2,7 @@ Fabricator(:post, :class_name => "TentD::Model::Post") do |f|
   f.entity "https://smith.example.com"
   f.public true
   f.original true
-  f.type "https://tent.io/types/posts/status"
+  f.type_base "https://tent.io/types/posts/status"
   f.type_version "0.1.0"
   f.licenses ["http://creativecommons.org/licenses/by-nc-sa/3.0/", "http://www.gnu.org/copyleft/gpl.html"]
   f.content {{ 'text' => "Debitis exercitationem et cum dolores dolor laudantium. Delectus sit eius id. Totam voluptatem et sunt consectetur sed facere debitis. Quia molestias ratione." }}

--- a/spec/integration/api/followers_spec.rb
+++ b/spec/integration/api/followers_spec.rb
@@ -110,8 +110,8 @@ describe TentD::API::Followers do
         }).to change(TentD::Model::Post, :count).by(1)
 
         post = TentD::Model::Post.last
-        expect(post.type).to eq('https://tent.io/types/post/follower')
-        expect(post.type_version).to eq('0.1.0')
+        expect(post.type.base).to eq('https://tent.io/types/post/follower')
+        expect(post.type.version).to eq('0.1.0')
         expect(post.content['action']).to eq('create')
       end
 
@@ -452,8 +452,8 @@ describe TentD::API::Followers do
         }).to change(TentD::Model::Post, :count).by(1)
 
         post = TentD::Model::Post.last
-        expect(post.type).to eq('https://tent.io/types/post/follower')
-        expect(post.type_version).to eq('0.1.0')
+        expect(post.type.base).to eq('https://tent.io/types/post/follower')
+        expect(post.type.version).to eq('0.1.0')
         expect(post.content['action']).to eq('delete')
       end
     end

--- a/spec/integration/api/posts_spec.rb
+++ b/spec/integration/api/posts_spec.rb
@@ -119,7 +119,7 @@ describe TentD::API::Posts do
       post_type_authorized = proc do
         context 'when post exists' do
           it 'should return post' do
-            post = Fabricate(:post, :public => false, :type => post_type)
+            post = Fabricate(:post, :public => false, :type_base => post_type)
             json_get "/posts/#{post.public_id}", params, env
             expect(last_response.status).to eq(200)
             expect(JSON.parse(last_response.body)['id']).to eq(post.public_id)
@@ -185,8 +185,8 @@ describe TentD::API::Posts do
         blog_post.type = blog_type_uri
         blog_post.save!
 
-        posts = TentD::Model::Post.all(:type => [picture_type_uri, blog_type_uri])
-        post_types = [picture_post, blog_post].map { |p| URI.escape(p.type.to_s, "://") }
+        posts = TentD::Model::Post.all(:type_base => [picture_type_uri, blog_type_uri])
+        post_types = [picture_post, blog_post].map { |p| URI.escape(p.type.uri, "://") }
 
         json_get "/posts?post_types=#{post_types.join(',')}", params, env
         body = JSON.parse(last_response.body)
@@ -451,7 +451,7 @@ describe TentD::API::Posts do
           deleted_post = post
           post = TentD::Model::Post.last
           expect(post.content['id']).to eq(deleted_post.public_id)
-          expect(post.type).to eq('https://tent.io/types/post/delete')
+          expect(post.type.base).to eq('https://tent.io/types/post/delete')
           expect(post.type_version).to eq('0.1.0')
         end
       end

--- a/spec/integration/api/profile_spec.rb
+++ b/spec/integration/api/profile_spec.rb
@@ -117,6 +117,8 @@ describe TentD::API::Profile do
 
           expect(last_response.status).to eq(200)
           expect(info.reload.content).to eq(data)
+
+          expect(TentD::Model::ProfileInfo.first.type).to eq(basic_info_type)
         end
 
         it 'should create unless exists' do

--- a/spec/integration/api/profile_spec.rb
+++ b/spec/integration/api/profile_spec.rb
@@ -59,8 +59,8 @@ describe TentD::API::Profile do
 
           json_get '/profile', params, env
           expect(last_response.body).to eq({
-            "#{ profile_infos.first.full_type }" => profile_infos.first.content,
-            "#{ profile_infos.last.full_type }" => profile_infos.last.content
+            "#{ profile_infos.first.type.uri }" => profile_infos.first.content,
+            "#{ profile_infos.last.type.uri }" => profile_infos.last.content
           }.to_json)
         end
       end
@@ -77,7 +77,7 @@ describe TentD::API::Profile do
 
           json_get '/profile', params, env
           expect(last_response.body).to eq({
-            "#{ profile_infos.first.full_type }" => profile_infos.first.content
+            "#{ profile_infos.first.type.uri }" => profile_infos.first.content
           }.to_json)
         end
       end
@@ -93,7 +93,7 @@ describe TentD::API::Profile do
 
         json_get '/profile', params, env
         expect(last_response.body).to eq({
-          "#{ profile_infos.first.full_type }" => profile_infos.first.content
+          "#{ profile_infos.first.type.uri }" => profile_infos.first.content
         }.to_json)
       end
     end
@@ -109,6 +109,8 @@ describe TentD::API::Profile do
         it 'should update info type' do
           info = create_info(basic_info_type, basic_info_content, :public => false)
 
+          expect(info.type.uri).to eq(basic_info_type)
+
           data = {
             "name" => "John Doe"
           }
@@ -118,7 +120,8 @@ describe TentD::API::Profile do
           expect(last_response.status).to eq(200)
           expect(info.reload.content).to eq(data)
 
-          expect(TentD::Model::ProfileInfo.first.type).to eq(basic_info_type)
+          expect(info.reload.type.uri).to eq(basic_info_type)
+          
         end
 
         it 'should create unless exists' do

--- a/spec/integration/model/notification_subscription_spec.rb
+++ b/spec/integration/model/notification_subscription_spec.rb
@@ -23,7 +23,7 @@ describe TentD::Model::NotificationSubscription do
 
   it 'should remove version and view from type' do
     instance = described_class.create(:type => "https://tent.io/types/posts/photo/v0.1.x#meta")
-    expect(instance.type).to eq('https://tent.io/types/posts/photo')
+    expect(instance.type.base).to eq('https://tent.io/types/posts/photo')
   end
 
   context "notifications" do

--- a/spec/integration/model/notification_subscription_spec.rb
+++ b/spec/integration/model/notification_subscription_spec.rb
@@ -30,6 +30,18 @@ describe TentD::Model::NotificationSubscription do
     let(:http_stubs) { Faraday::Adapter::Test::Stubs.new }
     let(:post) { Fabricate(:post) }
 
+    context "to everyone" do
+      let!(:subscription) { Fabricate(:notification_subscription, :follower => Fabricate(:follower)) }
+
+      it 'should notify about a post' do
+        TentClient.any_instance.stubs(:faraday_adapter).returns([:test, http_stubs])
+        http_stubs.post('/posts') { [200, {}, nil] }
+
+        described_class.notify_all(post.type, post.id)
+        http_stubs.verify_stubbed_calls
+      end
+    end
+
     context "to a follower" do
       let(:subscription) { Fabricate(:notification_subscription, :follower => Fabricate(:follower)) }
 

--- a/spec/integration/model/post_spec.rb
+++ b/spec/integration/model/post_spec.rb
@@ -90,6 +90,24 @@ describe TentD::Model::Post do
     end
   end
 
+  describe 'changing type' do
+    it 'updates the version and view' do
+      p = Fabricate(:post)
+      p.type = 'http://me.io/sometype/v0.1.0'
+      p.save!
+      expect(p.type_version).to eq('0.1.0')
+
+      p.update type_version: '0.1.0'
+
+      p = TentD::Model::Post.get(p.id)
+
+
+      p.type = 'http://mytype.io/v0.3.0'
+      p.save!
+      expect(p.type_version).to eq('0.3.0')
+    end
+  end
+
   describe 'fetch_with_permissions(params, current_auth)' do
     let(:group) { Fabricate(:group, :name => 'friends') }
     let(:params) { Hash.new }

--- a/spec/unit/tent_type_spec.rb
+++ b/spec/unit/tent_type_spec.rb
@@ -11,7 +11,18 @@ describe TentD::TentType do
     expect(instance.view).to eq('meta')
   end
 
-  it 'should parse base type uri' do
-    expect(instance.uri).to eq('https://tent.io/types/post/status')
+  it 'should parse base' do
+    expect(instance.base).to eq('https://tent.io/types/post/status')
+  end
+
+  it 'should reassemble URI' do
+    instance.version = '0.2.0'
+    expect(instance.uri.to_s).to eq("https://tent.io/types/post/status/v0.2.0#meta")
+  end
+
+  it 'should reassemble URI without version or view' do
+    instance.version = nil
+    instance.view = nil
+    expect(instance.uri.to_s).to eq("https://tent.io/types/post/status")
   end
 end


### PR DESCRIPTION
To store the type components properly, I renamed the `type` field to `type_base`.
`type` is now a virtual attribute that is a `TentType` with the values loaded from the fields mentioned above.

This streamlines the API a lot:

```
irb(main):008:0> post
=> #<TentD::Model::Post @public_id="ozxen8" @type_base="https://tent.io/types/posts/photo" @type_view=nil @type_version="0.1.0" @id=203 @entity="https://smith.example.com" @public=true @licenses=<not loaded> @content=<not loaded> @mentions=[] @published_at=#<DateTime: 2012-09-09T12:39:41+02:00 ((2456180j,38381s,0n),+7200s,2299161j)> @received_at=#<DateTime: 2012-09-09T12:39:41+02:00 ((2456180j,38381s,0n),+7200s,2299161j)> @updated_at=#<DateTime: 2012-09-09T12:39:41+02:00 ((2456180j,38381s,0n),+7200s,2299161j)> @app_name=nil @app_url=nil @original=true @known_entity=nil @app_id=nil>
irb(main):009:0> post.type
=> #<TentD::TentType:0x007f9884bdfe10 @version="0.1.0", @view=nil, @base="https://tent.io/types/posts/photo">
irb(main):010:0> post.type.base
=> "https://tent.io/types/posts/photo"
irb(main):011:0> post.type.version
=> "0.1.0"
irb(main):012:0> post.type.view
=> nil
irb(main):013:0> post.type.uri
=> "https://tent.io/types/posts/photo/v0.1.0"
irb(main):015:0> post.type = TentD::TentType.new('http://example.org/myothertype#ohai')
=> #<TentD::TentType:0x007f9884cae120 @version=, @view="ohai", @base="http://example.org/myothertype">
irb(main):016:0> post.type.uri
=> "http://example.org/myothertype#ohai"
```

`Post#type=` also accepts a string:

```
irb(main):017:0> post.type = 'http://tent.io/dat_type'
=> "http://tent.io/dat_type"
irb(main):018:0> post.type
=> #<TentD::TentType:0x007f9884cdbb70 @version=nil, @view=nil, @base="http://tent.io/dat_type">
```

Fixed #2.
