### PR TITLE
Clean the database between tests using database_cleaner

### DIFF
--- a/lib/tentd/api/posts.rb
+++ b/lib/tentd/api/posts.rb
@@ -101,11 +101,7 @@ module TentD
           data = env.params[:data].slice(*whitelisted_attributes(env))
           post = if env.params.data.id
             data.public_id = env.params.data.id
-            begin
-              Model::Post.create(data, :dont_notify_mentions => true)
-            rescue DataObjects::IntegrityError # hack to ignore duplicate posts
-              Model::Post.first(:public_id => data.public_id)
-            end
+            Model::Post.first(:public_id => data.public_id) || Model::Post.create(data, :dont_notify_mentions => true)
           else
             Model::Post.create(data)
           end

--- a/spec/integration/api/authentication_spec.rb
+++ b/spec/integration/api/authentication_spec.rb
@@ -36,8 +36,8 @@ describe 'Authentication' do
       context 'when follower' do
         let(:mac_key_id_prefix) { "s" }
         let(:subject) {
-          DataMapper.auto_migrate!
-          TentD::Model::User.current = TentD::Model::User.first_or_create
+          TentD::Model::Post.all.destroy!
+          TentD::Model::Follower.all.destroy!
           Fabricate(:follower, :mac_key_id => mac_key_id, :mac_algorithm => mac_algorithm, :mac_key => mac_key)
         }
 
@@ -47,8 +47,8 @@ describe 'Authentication' do
       context 'when following' do
         let(:mac_key_id_prefix) { "s" }
         let(:subject) {
-          DataMapper.auto_migrate!
-          TentD::Model::User.current = TentD::Model::User.first_or_create
+          TentD::Model::Post.all.destroy!
+          TentD::Model::Following.all.destroy!
           Fabricate(:following, :mac_key_id => mac_key_id, :mac_algorithm => mac_algorithm, :mac_key => mac_key)
         }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'fabrication'
 require 'tentd/core_ext/hash/slice'
 require 'girl_friday'
 require 'tentd/notifications/girl_friday'
+require 'database_cleaner'
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each { |f| require f }
 
@@ -32,6 +33,15 @@ RSpec.configure do |config|
     # DataMapper::Logger.new(STDOUT, :debug)
     DataMapper.setup(:default, ENV['TEST_DATABASE_URL'] || 'postgres://localhost/tent_server_test')
     DataMapper.auto_migrate!
+    DatabaseCleaner.strategy = :transaction
     TentD::Model::User.current = TentD::Model::User.first_or_create
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
   end
 end

--- a/tentd.gemspec
+++ b/tentd.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'mocha', '0.12.6'
   gem.add_development_dependency 'fabrication'
+  gem.add_development_dependency 'database_cleaner'
 end


### PR DESCRIPTION
When I first checked out tentd, I ran the tests (locally, on my own computer) and a couple of them failed. (issue #45, #21.) I found that these failures were triggered by stuff that was left in the database by previous tests.

The order in which `rake` runs the tests depends on the order of files in the spec directory and its subdirectories, which can be different from one machine to the next. The specific failures I was seeing didn't happen on Travis because on Travis the files are consistently run in an order that works.

Tests are more useful for reproducing and diagnosing problems when they're deterministic and independent of each other. So I've set up database_cleaner. It ensures each test starts with a clean database, by running each test within a database transaction and rolling back the transaction afterwards.
